### PR TITLE
Switch from Nest username/password to user_id/access_token

### DIFF
--- a/custom_components/badnest/__init__.py
+++ b/custom_components/badnest/__init__.py
@@ -1,17 +1,16 @@
 """The example integration."""
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
 from .api import NestAPI
-from .const import DOMAIN, CONF_ISSUE_TOKEN, CONF_COOKIE, CONF_REGION
+from .const import DOMAIN, CONF_ISSUE_TOKEN, CONF_COOKIE, CONF_USER_ID, CONF_ACCESS_TOKEN, CONF_REGION
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             {
-                vol.Required(CONF_EMAIL, default=""): cv.string,
-                vol.Required(CONF_PASSWORD, default=""): cv.string,
+                vol.Required(CONF_USER_ID, default=""): cv.string,
+                vol.Required(CONF_ACCESS_TOKEN, default=""): cv.string,
                 vol.Optional(CONF_REGION, default="us"): cv.string,
             },
             {
@@ -28,8 +27,8 @@ CONFIG_SCHEMA = vol.Schema(
 def setup(hass, config):
     """Set up the badnest component."""
     if config.get(DOMAIN) is not None:
-        email = config[DOMAIN].get(CONF_EMAIL)
-        password = config[DOMAIN].get(CONF_PASSWORD)
+        user_id = config[DOMAIN].get(CONF_USER_ID)
+        access_token = config[DOMAIN].get(CONF_ACCESS_TOKEN)
         issue_token = config[DOMAIN].get(CONF_ISSUE_TOKEN)
         cookie = config[DOMAIN].get(CONF_COOKIE)
         region = config[DOMAIN].get(CONF_REGION)
@@ -42,8 +41,8 @@ def setup(hass, config):
 
     hass.data[DOMAIN] = {
         'api': NestAPI(
-            email,
-            password,
+            user_id,
+            access_token,
             issue_token,
             cookie,
             region,

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -27,22 +27,20 @@ _LOGGER = logging.getLogger(__name__)
 
 class NestAPI():
     def __init__(self,
-                 email,
-                 password,
+                 user_id,
+                 access_token,
                  issue_token,
                  cookie,
                  region):
         self.device_data = {}
         self._wheres = {}
-        self._user_id = None
-        self._access_token = None
+        self._user_id = user_id
+        self._access_token = access_token
         self._session = requests.Session()
         self._session.headers.update({
             "Referer": "https://home.nest.com/",
             "User-Agent": USER_AGENT,
         })
-        self._email = email
-        self._password = password
         self._issue_token = issue_token
         self._cookie = cookie
         self._czfe_url = None
@@ -68,18 +66,9 @@ class NestAPI():
         return hasattr(self, name)
 
     def login(self):
-        if not self._email and not self._password:
+        if self._issue_token and self._cookie:
             self._login_google(self._issue_token, self._cookie)
-        else:
-            self._login_nest(self._email, self._password)
         self._login_dropcam()
-
-    def _login_nest(self, email, password):
-        r = self._session.post(
-            f"{API_URL}/session", json={"email": email, "password": password}
-        )
-        self._user_id = r.json()["userid"]
-        self._access_token = r.json()["access_token"]
 
     def _login_google(self, issue_token, cookie):
         headers = {

--- a/custom_components/badnest/const.py
+++ b/custom_components/badnest/const.py
@@ -1,4 +1,6 @@
 DOMAIN = 'badnest'
 CONF_ISSUE_TOKEN = 'issue_token'
 CONF_COOKIE = 'cookie'
+CONF_USER_ID = 'user_id'
+CONF_ACCESS_TOKEN = 'access_token'
 CONF_REGION = 'region'

--- a/info.md
+++ b/info.md
@@ -32,10 +32,17 @@ two-character country code, and it should work.
 
 ### Example configuration.yaml - When you're not using the Google Auth Login
 
+Google recently introduced reCAPTCHA when logging to Nest. That means username
+and password cannot be used directly any more. Instead, you have to obtain
+`user_id` and `access_token` for your account by logging in manually. To do that,
+open developer tools in your browser, switch to the "Network" tab, log in to Nest
+and look for the request similar to https://home.nest.com/session?_=1578693398448.
+You will find `user_id` and `access_token` in the response to the request.
+
 ```yaml
 badnest:
-  email: email@domain.com
-  password: !secret nest_password
+  user_id: 11111
+  access_token: !secret nest_access_token
   region: us
 
 climate:


### PR DESCRIPTION
Username and password can no longer be used directly because of reCAPTCHA.